### PR TITLE
fix: don't require AWS env vars

### DIFF
--- a/src/plugins/remote-cache/storage/s3.ts
+++ b/src/plugins/remote-cache/storage/s3.ts
@@ -11,22 +11,16 @@ export interface S3Options {
 
 // AWS_ envs are default for aws-sdk
 export function createS3({
-  accessKey = process.env.AWS_ACCESS_KEY_ID,
-  secretKey = process.env.AWS_SECRET_ACCESS_KEY,
+  accessKey = process.env.AWS_ACCESS_KEY_ID || process.env.S3_ACCESS_KEY,
+  secretKey = process.env.AWS_SECRET_ACCESS_KEY || process.env.S3_SECRET_KEY,
   bucket,
-  region = process.env.AWS_REGION,
+  region = process.env.AWS_REGION || process.env.S3_REGION,
   endpoint,
 }: S3Options) {
-  if (!accessKey || !secretKey || !(region || endpoint)) {
-    throw new Error(
-      `To use S3 storage "accessKey (S3_ACCESS_KEY)", "secretKey (S3_SECRET_KEY)", and one of "region (S3_REGION)" and "endpoint (S3_ENDPOINT)" parameters are mandatory.`,
-    )
-  }
   const client = new aws.S3({
-    credentials: {
-      accessKeyId: accessKey,
-      secretAccessKey: secretKey,
-    },
+    ...(accessKey && secretKey
+      ? { credentials: { accessKeyId: accessKey, secretAccessKey: secretKey } }
+      : {}),
     ...(region ? { region } : {}),
     ...(endpoint ? { endpoint: new aws.Endpoint(endpoint) } : {}),
     ...(process.env.NODE_ENV === 'test' ? { sslEnabled: false, s3ForcePathStyle: true } : {}),

--- a/test/vercel.ts
+++ b/test/vercel.ts
@@ -8,8 +8,8 @@ import vercel from '../src/vercel'
 test('vercel', t1 => {
   t1.test('should boot with no errors', async t2 => {
     t2.rejects(
-      // we are interested only in testing the boot phase
-      vercel({} as any, {} as any),
+      // @ts-expect-error -- we are interested only in testing the boot phase
+      vercel({}, {}),
       `Cannot read properties of undefined (reading 'length')`,
     )
     t2.end()


### PR DESCRIPTION
Same as #37 but with fallbacks for Vercel.