### PR TITLE
chore: head support

### DIFF
--- a/src/plugins/remote-cache/index.ts
+++ b/src/plugins/remote-cache/index.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify'
 import { badRequest, unauthorized } from '@hapi/boom'
-import { getArtifact, putArtifact, artifactsEvents } from './routes'
+import { getArtifact, putArtifact, artifactsEvents, headArtifact } from './routes'
 import { createLocation } from './storage'
 import { STORAGE_PROVIDERS } from '../../env'
 
@@ -64,6 +64,7 @@ async function turboRemoteCache(
   await instance.register(
     async function (i) {
       i.route(getArtifact)
+      i.route(headArtifact)
       i.route(putArtifact)
       i.route(artifactsEvents)
     },

--- a/src/plugins/remote-cache/routes/head-artifact.ts
+++ b/src/plugins/remote-cache/routes/head-artifact.ts
@@ -1,0 +1,32 @@
+import type { Server } from 'http'
+import type { RouteOptions, RawRequestDefaultExpression, RawReplyDefaultExpression } from 'fastify'
+import { notFound, badRequest } from '@hapi/boom'
+import { type Querystring, type Params, artifactsRouteSchema } from './schema'
+
+export const headArtifact: RouteOptions<
+  Server,
+  RawRequestDefaultExpression,
+  RawReplyDefaultExpression,
+  {
+    Querystring: Querystring
+    Params: Params
+  }
+> = {
+  method: 'HEAD',
+  url: '/artifacts/:id',
+  schema: artifactsRouteSchema,
+  async handler(req, reply) {
+    const artifactId = req.params.id
+    const teamId = req.query.teamId ?? req.query.slug // turborepo client passes teamId as slug when --team cli option is used
+    if (!teamId) {
+      throw badRequest(`querystring should have required property 'teamId'`)
+    }
+
+    try {
+      const artifact = await this.location.existsCachedArtifact(artifactId, teamId)
+      reply.send(artifact)
+    } catch (err) {
+      throw notFound(`Artifact not found`, err)
+    }
+  },
+}

--- a/src/plugins/remote-cache/routes/index.ts
+++ b/src/plugins/remote-cache/routes/index.ts
@@ -1,3 +1,4 @@
 export { getArtifact } from './get-artifact'
+export { headArtifact } from './head-artifact'
 export { putArtifact } from './put-artifact'
 export { artifactsEvents } from './artifacts-events'

--- a/src/plugins/remote-cache/storage/index.ts
+++ b/src/plugins/remote-cache/storage/index.ts
@@ -82,18 +82,36 @@ export function createLocation<Provider extends STORAGE_PROVIDERS>(
     })
   }
 
+  async function existsCachedArtifact(artifactId: string, teamId: string) {
+    return new Promise<void>((resolve, reject) => {
+      const artifactPath = join(teamId, artifactId)
+      location.exists(artifactPath, (err, exists) => {
+        if (err) {
+          return reject(err)
+        }
+        if (!exists) {
+          return reject(new Error(`Artifact ${artifactPath} doesn't exist.`))
+        }
+        resolve()
+      })
+    })
+  }
+
   async function createCachedArtifact(artifactId: string, teamId: string, artifact: Readable) {
     return pipeline(artifact, location.createWriteStream(join(teamId, artifactId)))
   }
+
   return {
     getCachedArtifact,
     createCachedArtifact,
+    existsCachedArtifact,
   }
 }
 
 declare module 'fastify' {
   interface FastifyInstance {
     location: {
+      existsCachedArtifact: ReturnType<typeof createLocation>['existsCachedArtifact']
       getCachedArtifact: ReturnType<typeof createLocation>['getCachedArtifact']
       createCachedArtifact: ReturnType<typeof createLocation>['createCachedArtifact']
     }

--- a/test/google-cloud-storage.ts
+++ b/test/google-cloud-storage.ts
@@ -143,7 +143,7 @@ tap.test('Google Cloud Storage', async t => {
       },
     })
     t2.equal(response.statusCode, 200)
-    t2.same(response.body, {})
+    t2.same(response.body, '')
   })
   t.test('should verify artifact does not exist', async t2 => {
     t2.plan(2)

--- a/test/google-cloud-storage.ts
+++ b/test/google-cloud-storage.ts
@@ -130,6 +130,36 @@ tap.test('Google Cloud Storage', async t => {
     t2.equal(response.statusCode, 200)
     t2.same(response.body, 'test cache data')
   })
+  t.test('should verify artifact exists', async t2 => {
+    t2.plan(2)
+    const response = await app.inject({
+      method: 'HEAD',
+      url: `/v8/artifacts/${artifactId}`,
+      headers: {
+        authorization: 'Bearer changeme',
+      },
+      query: {
+        teamId,
+      },
+    })
+    t2.equal(response.statusCode, 200)
+    t2.same(response.body, {})
+  })
+  t.test('should verify artifact does not exist', async t2 => {
+    t2.plan(2)
+    const response = await app.inject({
+      method: 'HEAD',
+      url: `/v8/artifacts/not-found`,
+      headers: {
+        authorization: 'Bearer changeme',
+      },
+      query: {
+        teamId,
+      },
+    })
+    t2.equal(response.statusCode, 404)
+    t2.same(response.body, {})
+  })
   t.test('should upload an artifact when slug is used', async t2 => {
     t2.plan(2)
     const response = await app.inject({

--- a/test/google-cloud-storage.ts
+++ b/test/google-cloud-storage.ts
@@ -158,7 +158,7 @@ tap.test('Google Cloud Storage', async t => {
       },
     })
     t2.equal(response.statusCode, 404)
-    t2.same(response.body, {})
+    t2.equal(response.json().message, 'Artifact not found')
   })
   t.test('should upload an artifact when slug is used', async t2 => {
     t2.plan(2)

--- a/test/local.ts
+++ b/test/local.ts
@@ -92,6 +92,36 @@ test(`local'`, async t => {
     t2.equal(response.statusCode, 200)
     t2.same(response.body, 'test cache data')
   })
+  t.test('should verify artifact exists', async t2 => {
+    t2.plan(2)
+    const response = await app.inject({
+      method: 'HEAD',
+      url: `/v8/artifacts/${artifactId}`,
+      headers: {
+        authorization: 'Bearer changeme',
+      },
+      query: {
+        teamId,
+      },
+    })
+    t2.equal(response.statusCode, 200)
+    t2.same(response.body, {})
+  })
+  t.test('should verify artifact does not exist', async t2 => {
+    t2.plan(2)
+    const response = await app.inject({
+      method: 'HEAD',
+      url: `/v8/artifacts/not-found`,
+      headers: {
+        authorization: 'Bearer changeme',
+      },
+      query: {
+        teamId,
+      },
+    })
+    t2.equal(response.statusCode, 404)
+    t2.same(response.body, {})
+  })
   t.test('should upload an artifact when slug is used', async t2 => {
     t2.plan(2)
     const response = await app.inject({

--- a/test/local.ts
+++ b/test/local.ts
@@ -120,7 +120,7 @@ test(`local'`, async t => {
       },
     })
     t2.equal(response.statusCode, 404)
-    t2.same(response.body, {})
+    t2.equal(response.json().message, 'Artifact not found')
   })
   t.test('should upload an artifact when slug is used', async t2 => {
     t2.plan(2)

--- a/test/local.ts
+++ b/test/local.ts
@@ -105,7 +105,7 @@ test(`local'`, async t => {
       },
     })
     t2.equal(response.statusCode, 200)
-    t2.same(response.body, {})
+    t2.same(response.body, '')
   })
   t.test('should verify artifact does not exist', async t2 => {
     t2.plan(2)

--- a/test/s3.ts
+++ b/test/s3.ts
@@ -134,7 +134,7 @@ server.run(err => {
         },
       })
       t2.equal(response.statusCode, 404)
-      t2.same(response.body, {})
+      t2.equal(response.json().message, 'Artifact not found')
     })
 
     t.teardown(() => {

--- a/test/s3.ts
+++ b/test/s3.ts
@@ -119,7 +119,7 @@ server.run(err => {
         },
       })
       t2.equal(response.statusCode, 200)
-      t2.same(response.body, {})
+      t2.same(response.body, '')
     })
     t.test('should verify artifact does not exist', async t2 => {
       t2.plan(2)

--- a/test/s3.ts
+++ b/test/s3.ts
@@ -106,6 +106,36 @@ server.run(err => {
       t2.equal(response.statusCode, 200)
       t2.same(response.body, 'test cache data')
     })
+    t.test('should verify artifact exists', async t2 => {
+      t2.plan(2)
+      const response = await app.inject({
+        method: 'HEAD',
+        url: `/v8/artifacts/${artifactId}`,
+        headers: {
+          authorization: 'Bearer changeme',
+        },
+        query: {
+          teamId,
+        },
+      })
+      t2.equal(response.statusCode, 200)
+      t2.same(response.body, {})
+    })
+    t.test('should verify artifact does not exist', async t2 => {
+      t2.plan(2)
+      const response = await app.inject({
+        method: 'HEAD',
+        url: `/v8/artifacts/not-found`,
+        headers: {
+          authorization: 'Bearer changeme',
+        },
+        query: {
+          teamId,
+        },
+      })
+      t2.equal(response.statusCode, 404)
+      t2.same(response.body, {})
+    })
 
     t.teardown(() => {
       server.close()


### PR DESCRIPTION
Turbo repo introduce support for `dry-run` to inspect caches and report on whether a cache entry in the local and/or remote cache exists for a given hash.   In order to leverage, remote cache implementors must implement a HEAD route to check for the resource.  This PR enables this.

See the following for references..

https://github.com/vercel/turborepo/issues/1437
https://github.com/vercel/turborepo/pull/1988

and this article for use cases on leveraging this new info reported by dry-run.

https://medium.com/@sppatel/maximizing-job-parallelization-in-ci-workflows-with-jest-and-turborepo-da86b9be0ee6