### PR TITLE
fix: Fixed problem with GCS_PRIVATE_KEY being escaped and causing an error

### DIFF
--- a/src/plugins/remote-cache/index.ts
+++ b/src/plugins/remote-cache/index.ts
@@ -56,7 +56,7 @@ async function turboRemoteCache(
       region: instance.config.S3_REGION,
       endpoint: instance.config.S3_ENDPOINT,
       clientEmail: instance.config.GCS_CLIENT_EMAIL,
-      privateKey: instance.config.GCS_PRIVATE_KEY,
+      privateKey: instance.config.GCS_PRIVATE_KEY?.replace(/\\n/g, '\n'),
       projectId: instance.config.GCS_PROJECT_ID,
     }),
   )


### PR DESCRIPTION
The following error occurs because GCS_PRIVATE_KEY cannot be read correctly due to `\n` being escaped when reading values from environment variables.

![image](https://user-images.githubusercontent.com/5005609/199073394-4d022806-3b33-4eab-a49b-4c963ffa4604.png)


The following link is helpful for this problem.
this issueshttps://github.com/googleapis/google-auth-library-nodejs/issues/1456#issuecomment-1240270318
