### PR TITLE
Feat/Application Default Credentials GCP auth

### DIFF
--- a/docs/supported-storage-providers.md
+++ b/docs/supported-storage-providers.md
@@ -21,13 +21,25 @@ Specify the region using the `AWS_REGION` environment variable, or in `~/.aws/co
 ## Configure Google Cloud Storage
 1. Create a [bucket](https://console.cloud.google.com/storage/browser) (or use an existing one)
 1. Create a new [service account](https://console.cloud.google.com/iam-admin/serviceaccounts) with a role of `Storage Object Viewer` and `Storage Object Creator`.
-1. Click "Create Key" and save the JSON file.
-1. Add the `project_id` , `client_email`, and `private_key` from saved JSON file to `.env` (or wherever you manage your environment variables):
   ```sh
   # .env
   STORAGE_PROVIDER=google-cloud-storage
   STORAGE_PATH=<name-of-the-bucket>
+  ```
+### Using static Service Account credentials
+1. Click "Create Key" and save the JSON file.
+1. Add the `project_id` , `client_email`, and `private_key` from saved JSON file to `.env` (or wherever you manage your environment variables):
+  ```sh
+  # .env
   GCS_PROJECT_ID=<project_id>
   GCS_CLIENT_EMAIL=<client_email>
   GCS_PRIVATE_KEY=<private_key>
+  ```
+### Using Application Default Credentials (ADC)
+1. Do not set `GCS_*` environment variables
+  ```sh
+  # .env
+  GCS_PROJECT_ID=
+  GCS_CLIENT_EMAIL=
+  GCS_PRIVATE_KEY=
   ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "turborepo-remote-cache",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "turborepo-remote-cache",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^6.4.1",
@@ -54,7 +54,7 @@
         "coveralls": "^3.1.1",
         "cross-env": "^7.0.3",
         "cz-conventional-changelog": "^3.3.0",
-        "dotenv": "^10.0.0",
+        "dotenv": "^14.1.0",
         "esbuild": "^0.14.5",
         "eslint": "^8.4.1",
         "eslint-config-prettier": "^8.3.0",
@@ -4022,11 +4022,12 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==",
+      "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/dotenv-expand": {
@@ -4182,6 +4183,14 @@
         "ajv": "^8.0.0",
         "dotenv": "^10.0.0",
         "dotenv-expand": "^5.1.0"
+      }
+    },
+    "node_modules/env-schema/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/error-ex": {
@@ -19247,9 +19256,10 @@
       }
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==",
+      "dev": true
     },
     "dotenv-expand": {
       "version": "5.1.0",
@@ -19397,6 +19407,13 @@
         "ajv": "^8.0.0",
         "dotenv": "^10.0.0",
         "dotenv-expand": "^5.1.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        }
       }
     },
     "error-ex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "turborepo-remote-cache",
-  "version": "1.6.6",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "turborepo-remote-cache",
-      "version": "1.6.6",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "coveralls": "^3.1.1",
     "cross-env": "^7.0.3",
     "cz-conventional-changelog": "^3.3.0",
-    "dotenv": "^10.0.0",
+    "dotenv": "^14.1.0",
     "esbuild": "^0.14.5",
     "eslint": "^8.4.1",
     "eslint-config-prettier": "^8.3.0",

--- a/src/plugins/remote-cache/storage/google-cloud-storage.ts
+++ b/src/plugins/remote-cache/storage/google-cloud-storage.ts
@@ -8,24 +8,34 @@ export interface GoogleCloudStorageOptions {
   privateKey: string
 }
 
+function createStorage({ clientEmail, privateKey, projectId }) {
+  if (!clientEmail || !privateKey || !projectId) {
+    console.log('using ADC')
+    return new Storage()
+  } else {
+    console.log('Using provided creds')
+    return new Storage({
+      projectId,
+      credentials: {
+        client_email: clientEmail,
+        private_key: privateKey,
+      },
+    })
+  }
+}
+
 export function createGoogleCloudStorage({
   bucket,
   clientEmail,
   privateKey,
   projectId,
 }: GoogleCloudStorageOptions): StorageProvider {
-  if (!clientEmail || !privateKey || !projectId) {
-    throw new Error(
-      `To use Google Cloud Storage "clientEmail (GCS_CLIENT_EMAIL)", "privateKey (GCS_PRIVATE_KEY)" and "projectId (GCS_PROJECT_ID)" parameters are mandatory.`,
-    )
-  }
-  const storage = new Storage({
+  const storage = createStorage({
+    clientEmail,
+    privateKey,
     projectId,
-    credentials: {
-      client_email: clientEmail,
-      private_key: privateKey,
-    },
   })
+
   const turboBucket = storage.bucket(bucket)
 
   return {

--- a/src/plugins/remote-cache/storage/google-cloud-storage.ts
+++ b/src/plugins/remote-cache/storage/google-cloud-storage.ts
@@ -10,10 +10,8 @@ export interface GoogleCloudStorageOptions {
 
 function createStorage({ clientEmail, privateKey, projectId }) {
   if (!clientEmail || !privateKey || !projectId) {
-    console.log('using ADC')
     return new Storage()
   } else {
-    console.log('Using provided creds')
     return new Storage({
       projectId,
       credentials: {

--- a/test/.env.google-cloud-storage.adc
+++ b/test/.env.google-cloud-storage.adc
@@ -1,0 +1,8 @@
+NODE_ENV=test
+PORT=3000
+TURBO_TOKEN=changeme
+STORAGE_PROVIDER=google-cloud-storage
+STORAGE_PATH=turborepo-remote-cache-test
+GCS_PROJECT_ID=
+GCS_CLIENT_EMAIL=
+GCS_PRIVATE_KEY=

--- a/test/google-cloud-storage.ts
+++ b/test/google-cloud-storage.ts
@@ -191,4 +191,24 @@ tap.test('Google Cloud Storage', async t => {
     t2.equal(response.statusCode, 200)
     t2.same(response.json(), {})
   })
+  t.test('should upload an artifact when using ADC credentials', async t2 => {
+    t2.plan(2)
+
+    dotenv.config({ path: join(__dirname, '.env.google-cloud-storage.adc'), override: true })
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/v8/artifacts/${artifactId}`,
+      headers: {
+        authorization: 'Bearer changeme',
+        'content-type': 'application/octet-stream',
+      },
+      query: {
+        teamId,
+      },
+      payload: Buffer.from('test cache data'),
+    })
+    t2.equal(response.statusCode, 200)
+    t2.same(response.json(), { urls: [`${teamId}/${artifactId}`] })
+  })
 })

--- a/test/google-cloud-storage.ts
+++ b/test/google-cloud-storage.ts
@@ -191,10 +191,27 @@ tap.test('Google Cloud Storage', async t => {
     t2.equal(response.statusCode, 200)
     t2.same(response.json(), {})
   })
+})
+
+dotenv.config({ path: join(__dirname, '.env.google-cloud-storage.adc'), override: true })
+const mockAppADC = tap.mock('../src/app', {
+  '@google-cloud/storage': {
+    Storage: class MockStorage {
+      bucket(name: string) {
+        return new GCSMockBucket(name)
+      }
+    },
+  },
+})
+
+tap.test('Google Cloud Storage', async t => {
+  const artifactId = crypto.randomBytes(20).toString('hex')
+  const teamId = 'superteam'
+  const app = mockAppADC.createApp({ logger: false })
+  await app.ready()
+
   t.test('should upload an artifact when using ADC credentials', async t2 => {
     t2.plan(2)
-
-    dotenv.config({ path: join(__dirname, '.env.google-cloud-storage.adc'), override: true })
 
     const response = await app.inject({
       method: 'PUT',


### PR DESCRIPTION
From [docs](https://cloud.google.com/docs/authentication/application-default-credentials):

>ADC is a strategy used by [Cloud Client Libraries and Google API Client Libraries](https://cloud.google.com/apis/docs/client-libraries-explained) to automatically find credentials based on the application environment, and use those credentials to authenticate to Google Cloud APIs. When you set up ADC and use a client library, your code can run in either a development or production environment without changing how your application authenticates to Google Cloud services and APIs.

>    ADC searches for credentials in the following locations:
>    [GOOGLE_APPLICATION_CREDENTIALS environment variable](https://cloud.google.com/docs/authentication/application-default-credentials#GAC)
>    [User credentials set up with the Google Cloud CLI](https://cloud.google.com/docs/authentication/application-default-credentials#personal)
>    [The attached service account, as provided by the metadata server](https://cloud.google.com/docs/authentication/application-default-credentials#attached-sa)

By simply not providing credentials to Storage() constructor we instruct it to use one of the above three ADC methods. The 2nd and 3rd scenarios are most common in my experience - SDK knows where to find local credentials, and it will also check the GCP metadata server for the Service Account information (this is used for Workload Identity auth in GKE - the recommended way to authenticate with GCP. Very similar to AWS's IAM roles for service accounts/IRSA)

A slightly different approach to an existing PR https://github.com/ducktors/turborepo-remote-cache/pull/66:
*Use ADC if no explicit credentials were provided. Many tools that use GCP SDK follow this logic.