### PR TITLE
fix: remove need for VERCEL_*

### DIFF
--- a/docs/custom-remote-caching.md
+++ b/docs/custom-remote-caching.md
@@ -43,8 +43,3 @@ For some reason, the `.turbo/config.json` is not working in Docker containers. I
 ```json
     "build": "turbo run build --team=\"team_awesome\" --token=\"turbotoken\" --api=\"https://your-caching.server.dev\"",
 ```
-and add this to your `Dockerfile` before calling the `turbo run build` command:
-```docker
-ENV VERCEL_ARTIFACTS_TOKEN=turbotoken
-ENV VERCEL_ARTIFACTS_OWNER=team_awesome
-```


### PR DESCRIPTION
## In this PR:

- Removes need for defining the VERCEL_* envs since the PR to fix this was merged by the Vercel team a few months ago

## Issues reference: 
 - https://github.com/ducktors/turborepo-remote-cache/issues/34#issuecomment-1183651684
 - https://github.com/vercel/turbo/pull/1527

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ducktors/turborepo-remote-cache/pulls) for the same update/change?
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
* [X] Have you lint your code with `npm run lint` locally prior to submission?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you commit using [Conventional Commits](https://github.com/ducktors/turborepo-remote-cache#how-to-commit)
