### PR TITLE
feat: use AWS_SESSION_TOKEN

### DIFF
--- a/docs/supported-storage-providers.md
+++ b/docs/supported-storage-providers.md
@@ -16,6 +16,10 @@ AWS credentials and configuration are loaded as described in the AWS SDK documen
 For example, you can set environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or create a file
 `~/.aws/credentials` with AWS credentials.
 
+If running in an AWS Lambda Function, temporary credentials (including an
+`AWS_SESSION_TOKEN`) are automatically created and you do not need to manually
+configure these.
+
 Specify the region using the `AWS_REGION` environment variable, or in `~/.aws/config`.
 
 ## Configure Google Cloud Storage

--- a/src/plugins/remote-cache/storage/s3.ts
+++ b/src/plugins/remote-cache/storage/s3.ts
@@ -19,7 +19,13 @@ export function createS3({
 }: S3Options) {
   const client = new aws.S3({
     ...(accessKey && secretKey
-      ? { credentials: { accessKeyId: accessKey, secretAccessKey: secretKey } }
+      ? {
+          credentials: {
+            accessKeyId: accessKey,
+            secretAccessKey: secretKey,
+            sessionToken: process.env.AWS_SESSION_TOKEN,
+          },
+        }
       : {}),
     ...(region ? { region } : {}),
     ...(endpoint ? { endpoint: new aws.Endpoint(endpoint) } : {}),


### PR DESCRIPTION
## In this PR:

This PR allows the S3 storage provider to use an `AWS_SESSION_TOKEN` if this has been set in the current environment. This is a non-breaking change.

*Note - this is the same kind of functionality that @wdalmijn was looking to implement in #36, but as this has been open for a few months and appears to have outstanding conflicts with the new codebase I started from a new fork. This is also a smaller change as there probably isn't a need for users to set this manually.*

## Rationale

This is required to run the server in an AWS Lambda Function. Unlike a long running server, the Lambda Function generates temporary credentials to allow the handler to access other AWS resources, and uses the `AWS_SESSION_TOKEN` to achieve this. Without passing this token any calls made via the sdk will fail.

This change just passes the `AWS_SESSION_TOKEN` to the S3 sdk if present.

I did not implement this as an option to be set by the user. I had a good think about this, but there are only very limited circumstances where an `AWS_SESSION_TOKEN` needs to be included, and where this happens it will have already been created as an environment variable. As this is a temporary credential that expires a user wouldn't need to set this for a long-running server, and including this might cause confusion.

## How has this been tested?

As with comments in #36, there aren't any existing tests on passing credentials, so I have manually tested this.

I have built and uploaded a server to a Lambda Function, and verified this creates and retrieves the turbo artefacts from an S3 bucket when called from the `turbo` client.

I have also regression tested by creating a local client with `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables set to make sure that it still works as expected where no `AWS_SESSION_TOKEN` has been set.

## Issues reference:
 - #28
