### PR TITLE
feat: Emit d.ts files in build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "build",
     "pretty": true,
     "noEmitOnError": true,
+    "declaration": true,
     "sourceMap": true,
     "inlineSources": true,
     "strict": true,


### PR DESCRIPTION
## In this PR:

Sorry for a bunch of PRs to review, I only thought of this small addition late on! 

Non-breaking change. Emits `d.ts` files in build. This makes writing a proxy for the server nicer for typescript users.

Closes #88

## Issues reference:
 - #88