### PR TITLE
fix: minor doc fixes

### DIFF
--- a/docs/deployment-environments.md
+++ b/docs/deployment-environments.md
@@ -3,6 +3,7 @@ layout: default
 title: Deployment Environments
 nav_order: 4
 has_children: true
+has_toc: false
 ---
 
 # Deployment Environments
@@ -46,8 +47,7 @@ The server can be easily deployed on DigitalOcean App Service.
 
 __Note: Local storage isn't supported for this deployment method.__
 
-[![Deploy to
-DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/ducktors/turborepo-remote-cache/tree/main)
+[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/ducktors/turborepo-remote-cache/tree/main)
 
 ## Deploy on AWS Lambda
 This server can be deployed as an AWS Lambda Function. See this

--- a/docs/running-in-lambda.md
+++ b/docs/running-in-lambda.md
@@ -94,9 +94,9 @@ variables:
 
 | Variable            | Value              |
 |--------------------|--------------------|
-| `STORAGE_PATH`     | <your_bucket_name> | 
+| `STORAGE_PATH`     | *your_bucket_name* | 
 | `STORAGE_PROVIDER` | s3                 |
-| `TURBO_TOKEN`      | <your_secret_key>  |
+| `TURBO_TOKEN`      | *your_secret_key*  |
 
 *See [Environment
 variables](https://ducktors.github.io/turborepo-remote-cache/environment-variables)


### PR DESCRIPTION
## In this PR:

Some minor fixes to the docs I noticed after they were converted to Jekyll: 

- The values of the environment variables on the `Running in Lambda` page are being converted to HTML tags :man_facepalming:, changed these to italics makes sure they display
- Disabled the Table of Contents from being auto-generated at the bottom of the `Deployment Environments` page, it's not necessary
- And removed an erroneous newline I seem to have managed to introduce into the `Deploy to DO` button (the button continues to render and work, but the newline shouldn't be there)