### PR TITLE
Fastify: Incorrect Content-Type parsing can lead to CSRF attack 

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "boom": "7.3.0",
     "close-with-grace": "1.1.0",
     "env-schema": "5.1.0",
-    "fastify": "3.25.0",
+    "fastify": "3.29.4",
     "fastify-autoload": "3.9.0",
     "fastify-plugin": "3.0.0",
     "fs-blob-store": "6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ specifiers:
   eslint: ^8.4.1
   eslint-config-prettier: ^8.3.0
   eslint-plugin-prettier: ^4.0.0
-  fastify: 3.25.0
+  fastify: 3.29.4
   fastify-autoload: 3.9.0
   fastify-plugin: 3.0.0
   fs-blob-store: 6.0.0
@@ -71,7 +71,7 @@ dependencies:
   boom: 7.3.0
   close-with-grace: 1.1.0
   env-schema: 5.1.0
-  fastify: 3.25.0
+  fastify: 3.29.4
   fastify-autoload: 3.9.0
   fastify-plugin: 3.0.0
   fs-blob-store: 6.0.0
@@ -544,6 +544,10 @@ packages:
 
   /@fastify/aws-lambda/3.1.3:
     resolution: {integrity: sha512-5bE17UqQlzja83XIOEvE0pNoDidbfNVu7R+DGus2uFECIg1m0o77XnRCEd9pzuP7ZOQmiRLrQdcET9ki+hSaVw==}
+    dev: false
+
+  /@fastify/error/2.0.0:
+    resolution: {integrity: sha512-wI3fpfDT0t7p8E6dA2eTECzzOd+bZsZCJ2Hcv+Onn2b7ZwK3RwD27uW2QDaMtQhAfWQQP+WNK7nKf0twLsBf9w==}
     dev: false
 
   /@google-cloud/paginator/3.0.7:
@@ -1851,7 +1855,6 @@ packages:
   /content-type/1.0.4:
     resolution: {integrity: sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /conventional-changelog-angular/5.0.13:
     resolution: {integrity: sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==}
@@ -2792,10 +2795,6 @@ packages:
       semver: 7.3.7
     dev: false
 
-  /fastify-error/0.3.1:
-    resolution: {integrity: sha512-oCfpcsDndgnDVgiI7bwFKAun2dO+4h84vBlkWsWnz/OUK9Reff5UFoFl241xTiLeHWX/vU9zkDVXqYUxjOwHcQ==}
-    dev: false
-
   /fastify-plugin/3.0.0:
     resolution: {integrity: sha512-ZdCvKEEd92DNLps5n0v231Bha8bkz1DjnPP/aEz37rz/q42Z5JVLmgnqR4DYuNn3NXAO3IDCPyRvgvxtJ4Ym4w==}
     dev: false
@@ -2805,24 +2804,25 @@ packages:
     deprecated: This module renamed to process-warning
     dev: false
 
-  /fastify/3.25.0:
-    resolution: {integrity: sha512-GblpjS7yuJ9jpkz1guHTyzlVQn9NYvGrMkDLtoxctEt7n1d6MSwA9i3p10HjNiY+zVurPf3YdOqXsJmVgAR3cg==}
+  /fastify/3.29.4:
+    resolution: {integrity: sha512-BEyKidZQvscNaiF1BLh+YLE7AzHH03NexhPzrwZP6KBQ+jG2czdgq72X+RFB5rK9hbqdaafVb5yiWN+hCvHfYg==}
     dependencies:
       '@fastify/ajv-compiler': 1.1.0
+      '@fastify/error': 2.0.0
       abstract-logging: 2.0.1
       avvio: 7.2.2
+      content-type: 1.0.4
       fast-json-stringify: 2.7.12
-      fastify-error: 0.3.1
-      fastify-warning: 0.2.0
       find-my-way: 4.5.0
       flatstr: 1.0.12
       light-my-request: 4.7.0
       pino: 6.13.3
+      process-warning: 1.0.0
       proxy-addr: 2.0.7
       rfdc: 1.3.0
       secure-json-parse: 2.4.0
       semver: 7.3.7
-      tiny-lru: 7.0.6
+      tiny-lru: 8.0.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5056,6 +5056,10 @@ packages:
       fromentries: 1.3.2
     dev: true
 
+  /process-warning/1.0.0:
+    resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
+    dev: false
+
   /progress/2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -6049,8 +6053,8 @@ packages:
     dependencies:
       readable-stream: 3.6.0
 
-  /tiny-lru/7.0.6:
-    resolution: {integrity: sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==}
+  /tiny-lru/8.0.2:
+    resolution: {integrity: sha512-ApGvZ6vVvTNdsmt676grvCkUCGwzG9IqXma5Z07xJgiC5L7akUMof5U8G2JTI9Rz/ovtVhJBlY6mNhEvtjzOIg==}
     engines: {node: '>=6'}
     dev: false
 


### PR DESCRIPTION
## In this PR:

- [Update Fastify from 3.25.0 to 3.29.4](https://github.com/ducktors/turborepo-remote-cache/security/dependabot/5
)
