### PR TITLE
docs(gcs): role Storage Object Admin is required but not mentioned

### DIFF
--- a/docs/supported-storage-providers.md
+++ b/docs/supported-storage-providers.md
@@ -24,7 +24,8 @@ Specify the region using the `AWS_REGION` environment variable, or in `~/.aws/co
 
 ## Configure Google Cloud Storage
 1. Create a [bucket](https://console.cloud.google.com/storage/browser) (or use an existing one)
-1. Create a new [service account](https://console.cloud.google.com/iam-admin/serviceaccounts) with a role of `Storage Object Viewer` and `Storage Object Creator`.
+2. Create a new [service account](https://console.cloud.google.com/iam-admin/serviceaccounts).
+3. Grant the role `Storage Object Admin` to the service account on the bucket.
   ```sh
   # .env
   STORAGE_PROVIDER=google-cloud-storage


### PR DESCRIPTION
docs(gcs): Storage Object Admin is required but not mentioned

## In this PR:

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Issues reference:
 - https://github.com/ducktors/turborepo-remote-cache/issues/95

### Checklist:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ducktors/turborepo-remote-cache/pulls) for the same update/change?
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
* [ ] Have you lint your code with `pnpm lint` locally prior to submission?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran build with `pnpm build` of your changes locally?
* [ ] Have you successfully ran tests with `pnpm test` of your changes locally?
* [x] Have you commit using [Conventional Commits](https://github.com/ducktors/turborepo-remote-cache#how-to-commit)?
