### PR TITLE
update lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2500,7 +2500,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       globby: 11.1.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       is-glob: 4.0.3
       is-path-cwd: 2.2.0
       is-path-inside: 3.0.3
@@ -3373,7 +3373,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.0
     dev: true


### PR DESCRIPTION
Currently, Docker image fails to build because since pnpm v8, the lockfile format changed, causing Docker image build failure.

This PR just updates the lockfile.

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/193136/234853781-baaab0de-ee51-4f86-abe6-a60f2b6e0500.png">
