### PR TITLE
Allow specifying the bodyLimit as an environment variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { env } from './env'
 
 const app = createApp({
   trustProxy: true,
+  bodyLimit: process.env.BODY_LIMIT !== undefined ? Number(process.env.BODY_LIMIT) : undefined,
 })
 
 closeWithGrace(


### PR DESCRIPTION
## In this PR:

This PR adds the ability to specify the body limit as an environment variable. We've hit the error `FastifyError: Request body is too large` in our largest application build, and to solve this we need to bump the Fastify request body limit.

I'm categorizing this as a bugfix, but I'm happy to change the categorization!

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ducktors/turborepo-remote-cache/pulls) for the same update/change?
* [x] Have you lint your code with `pnpm lint` locally prior to submission?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you commit using [Conventional Commits](https://github.com/ducktors/turborepo-remote-cache#how-to-commit)?
