### PR TITLE
fix: remove pnpm from package engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x, 18.x, 20.x]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
         name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,19 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install with npm
-        run: npm install turborepo-remote-cache
+        run: |
+          cd ${{ github.workspace }}
+          mkdir npm-repro
+          cd npm-repro
+          npm init -y
+          npm install turborepo-remote-cache
       - name: Install with yarn
-        run: yarn add turborepo-remote-cache
+        run: |
+          cd ${{ github.workspace }}
+          mkdir yarn-repro
+          cd yarn-repro
+          npm init -y
+          yarn add turborepo-remote-cache
 
   build:
     runs-on: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -98,8 +98,7 @@
     "test": "test"
   },
   "engines": {
-    "node": ">=18",
-    "pnpm": ">=8"
+    "node": ">=16"
   },
   "packageManager": "pnpm@8.3.1",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -98,9 +98,9 @@
     "test": "test"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=16.20"
   },
-  "packageManager": "pnpm@8.3.1",
+  "packageManager": "pnpm@8.6.3",
   "keywords": [
     "turborepo",
     "monorepo",


### PR DESCRIPTION
## In this PR:

- This update addresses issues with installing packages using npm or yarn on Node versions below 18.

## Issues reference:
 - https://github.com/ducktors/turborepo-remote-cache/issues/178


