### PR TITLE
docs: update lambda docs to use function urls

### DIFF
--- a/docs/running-in-lambda.md
+++ b/docs/running-in-lambda.md
@@ -13,7 +13,7 @@ through creating:
 - An S3 bucket to store the artifacts
 - An IAM role to grant the Lambda permission to access the bucket
 - The Lambda function
-- An HTTP API Gateway
+- A Lambda Function URL
 - Configuring your repository to use the new API
 
 ## Create S3 Bucket to store artifacts
@@ -94,7 +94,7 @@ variables:
 
 | Variable            | Value              |
 |--------------------|--------------------|
-| `STORAGE_PATH`     | *your_bucket_name* | 
+| `STORAGE_PATH`     | *your_bucket_name* |
 | `STORAGE_PROVIDER` | s3                 |
 | `TURBO_TOKEN`      | *your_secret_key*  |
 
@@ -102,26 +102,21 @@ variables:
 variables](https://ducktors.github.io/turborepo-remote-cache/environment-variables)
 for more information on configuring these.*
 
-### ARN
+### Function URL
 
-Copy your Lambda's ARN for the next step.
+Under your Lambda **Configuration**, head to **Function URL** and click on **Create function URL**.
 
-## Create an HTTP API Gateway
+Select **Auth type**: `NONE`.
 
-Go to the API Gateway service, and choose **Create**. Under **HTTP API** click
-on **Build**. 
+Open Additional settings and enable **CORS** with the following settings:
 
-Under **Integrations** click on **Add integration**. Choose **Lambda** and
-search for your Lambda's ARN. Enter an API name such as `turborepo-cache-api`.
+- Allow origin: `*`
+- Allow headers: `*`
+- Allow methods: `*`
 
-Under **Configure routes** leave the **Method** as `ANY` and change the
-**Resource path** to `$default`. Click on **Next**.
+Click on **Save**.
 
-On the **Configure stages** screen, leave the stage name as `$default` and click
-on **Next**, then on the **Review and create** screen click on **Create**.
-
-You have now created your API Gateway. Copy the **Invoke URL** and use this to
-set up your repository.
+Copy the **Function URL** and use this to set up your repository.
 
 ## Configuring your repository to use the new API
 


### PR DESCRIPTION
## In this PR:

- update docs to use an AWS Lambda function url instead of the API Gateway HTTP API

Function URLs are much simpler to setup and work the same way as the setup with the HTTP API. The request and response event formats follow the same schema as the Amazon API Gateway payload format version 2.0, see [AWS docs](https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html).

I've setup an AWS CDK construct to quickly create such configuration, it's already published to npm/constructs.dev, see [cdk-turborepo-remote-cache](https://github.com/NimmLor/cdk-turborepo-remote-cache)


### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ducktors/turborepo-remote-cache/pulls) for the same update/change?
