### PR TITLE
fix: Turbos api now uses team instead of teamId

### DIFF
--- a/docs/custom-remote-caching.md
+++ b/docs/custom-remote-caching.md
@@ -31,13 +31,13 @@ For example:
 Now, you need to add these two environment variables TURBO_TEAM and TURBO_TOKEN to your CI pipeline or development machine. There are three ways to do it:
 
 1. Set/export the `TURBO_TEAM=ducktors` and`TURBO_TOKEN=myGeneratedToken` as environment variable.
-2. Add `teamId` and `token` to the *turbo* global config file. You can find or create it inside the `$XDG_CONFIG_HOME/turborepo/config.json`. To know where the`XDG_CONFIG_HOME` is located on your machine, please check out the [xdg-base-directory](https://github.com/adrg/xdg#xdg-base-directory) documentation. For example:
+2. Add `team` and `token` to the *turbo* global config file. You can find or create it inside the `$XDG_CONFIG_HOME/turborepo/config.json`. To know where the`XDG_CONFIG_HOME` is located on your machine, please check out the [xdg-base-directory](https://github.com/adrg/xdg#xdg-base-directory) documentation. For example:
 
     `.turbo/config.json`
 
     ```json
     {
-      "teamid": "ducktors",
+      "team": "ducktors",
       "token" : "myGeneratedToken",
       "apiurl": "http://cache.ducktors.dev"
     }
@@ -50,7 +50,7 @@ For example:
 `package.json`
 ```jsonc
 //...
-  "build": "turbo run build --teamid=\"ducktors\" --token=\"myGeneratedToken\"",
+  "build": "turbo run build --team=\"ducktors\" --token=\"myGeneratedToken\"",
   "dev": "turbo run dev --parallel",
   "lint": "turbo run lint",
   "format": "prettier --write \"**/*.{ts,tsx,md}\""
@@ -90,7 +90,7 @@ You can also configure your development machine by setting the following environ
 | Variable      | Type   | Description |
 | ------------- | ------ | ----------- |
 | `TURBO_API`   | string | The address of a running `turborepo-remote-cache` server |
-| `TURBO_TEAM`  | string | The teamId (see *Config file* above)|
+| `TURBO_TEAM`  | string | The team (see *Config file* above)|
 | `TURBO_TOKEN` | string | Your secret key. This must be the same as the `TURBO_TOKEN` variable set on your turborepo-remote-cache server instance |
 
 **Note: these environment variables are used by the Turborepo CLI** on the development machine or CI pipelines. They are not used by the `turborepo-remote-cache` server.

--- a/src/plugins/remote-cache/routes/get-artifact.ts
+++ b/src/plugins/remote-cache/routes/get-artifact.ts
@@ -26,7 +26,7 @@ export const getArtifact: RouteOptions<
   schema: artifactsRouteSchema,
   async handler(req, reply) {
     const artifactId = req.params.id
-    const team = req.query.team ?? req.query.slug // turborepo client passes team as slug when --team cli option is used
+    const team = req.query.teamId ?? req.query.team ?? req.query.slug // turborepo client passes team as slug when --team cli option is used
     if (!team) {
       throw badRequest(`querystring should have required property 'team'`)
     }

--- a/src/plugins/remote-cache/routes/get-artifact.ts
+++ b/src/plugins/remote-cache/routes/get-artifact.ts
@@ -26,13 +26,13 @@ export const getArtifact: RouteOptions<
   schema: artifactsRouteSchema,
   async handler(req, reply) {
     const artifactId = req.params.id
-    const teamId = req.query.teamId ?? req.query.slug // turborepo client passes teamId as slug when --team cli option is used
-    if (!teamId) {
-      throw badRequest(`querystring should have required property 'teamId'`)
+    const team = req.query.team ?? req.query.slug // turborepo client passes team as slug when --team cli option is used
+    if (!team) {
+      throw badRequest(`querystring should have required property 'team'`)
     }
 
     try {
-      const artifact = await this.location.getCachedArtifact(artifactId, teamId)
+      const artifact = await this.location.getCachedArtifact(artifactId, team)
       reply.header('Content-Type', 'application/octet-stream')
       return reply.send(artifact)
     } catch (err) {

--- a/src/plugins/remote-cache/routes/head-artifact.ts
+++ b/src/plugins/remote-cache/routes/head-artifact.ts
@@ -25,7 +25,7 @@ export const headArtifact: RouteOptions<
   schema: artifactsRouteSchema,
   async handler(req, reply) {
     const artifactId = req.params.id
-    const team = req.query.team ?? req.query.slug // turborepo client passes team as slug when --team cli option is used
+    const team = req.query.teamId ?? req.query.team ?? req.query.slug // turborepo client passes team as slug when --team cli option is used
     if (!team) {
       throw badRequest(`querystring should have required property 'team'`)
     }

--- a/src/plugins/remote-cache/routes/head-artifact.ts
+++ b/src/plugins/remote-cache/routes/head-artifact.ts
@@ -25,15 +25,15 @@ export const headArtifact: RouteOptions<
   schema: artifactsRouteSchema,
   async handler(req, reply) {
     const artifactId = req.params.id
-    const teamId = req.query.teamId ?? req.query.slug // turborepo client passes teamId as slug when --team cli option is used
-    if (!teamId) {
-      throw badRequest(`querystring should have required property 'teamId'`)
+    const team = req.query.team ?? req.query.slug // turborepo client passes team as slug when --team cli option is used
+    if (!team) {
+      throw badRequest(`querystring should have required property 'team'`)
     }
 
     try {
       const artifact = await this.location.existsCachedArtifact(
         artifactId,
-        teamId,
+        team,
       )
       reply.send(artifact)
     } catch (err) {

--- a/src/plugins/remote-cache/routes/put-artifact.ts
+++ b/src/plugins/remote-cache/routes/put-artifact.ts
@@ -27,19 +27,19 @@ export const putArtifact: RouteOptions<
   schema: artifactsRouteSchema,
   async handler(req, reply) {
     const artifactId = req.params.id
-    const teamId = req.query.teamId ?? req.query.slug // turborepo client passes teamId as slug when --team cli option is used
-    if (!teamId) {
-      throw badRequest(`querystring should have required property 'teamId'`)
+    const team = req.query.team ?? req.query.slug // turborepo client passes team as slug when --team cli option is used
+    if (!team) {
+      throw badRequest(`querystring should have required property 'team'`)
     }
 
     try {
       await this.location.createCachedArtifact(
         artifactId,
-        teamId,
+        team,
         Readable.from(req.body),
       )
 
-      reply.send({ urls: [`${teamId}/${artifactId}`] })
+      reply.send({ urls: [`${team}/${artifactId}`] })
     } catch (err) {
       // we need this error throw since turbo retries if the error is in 5xx range
       throw preconditionFailed('Error during the artifact creation', err)

--- a/src/plugins/remote-cache/routes/put-artifact.ts
+++ b/src/plugins/remote-cache/routes/put-artifact.ts
@@ -27,7 +27,7 @@ export const putArtifact: RouteOptions<
   schema: artifactsRouteSchema,
   async handler(req, reply) {
     const artifactId = req.params.id
-    const team = req.query.team ?? req.query.slug // turborepo client passes team as slug when --team cli option is used
+    const team = req.query.teamId ?? req.query.team ?? req.query.slug // turborepo client passes team as slug when --team cli option is used
     if (!team) {
       throw badRequest(`querystring should have required property 'team'`)
     }

--- a/src/plugins/remote-cache/routes/schema.ts
+++ b/src/plugins/remote-cache/routes/schema.ts
@@ -2,6 +2,7 @@ import { Static, Type } from '@sinclair/typebox'
 
 const querystring = Type.Object(
   {
+    teamId: Type.Optional(Type.String()),
     team: Type.Optional(Type.String()),
     slug: Type.Optional(Type.String()),
   },

--- a/src/plugins/remote-cache/routes/schema.ts
+++ b/src/plugins/remote-cache/routes/schema.ts
@@ -2,7 +2,7 @@ import { Static, Type } from '@sinclair/typebox'
 
 const querystring = Type.Object(
   {
-    teamId: Type.Optional(Type.String()),
+    team: Type.Optional(Type.String()),
     slug: Type.Optional(Type.String()),
   },
   { additionalProperties: false },

--- a/src/plugins/remote-cache/storage/index.ts
+++ b/src/plugins/remote-cache/storage/index.ts
@@ -106,9 +106,9 @@ export function createLocation<Provider extends STORAGE_PROVIDERS>(
 ) {
   const location = createStorageLocation(provider, providerOptions)
 
-  async function getCachedArtifact(artifactId: string, teamId: string) {
+  async function getCachedArtifact(artifactId: string, team: string) {
     return new Promise((resolve, reject) => {
-      const artifactPath = join(teamId, artifactId)
+      const artifactPath = join(team, artifactId)
       location.exists(artifactPath, (err, exists) => {
         if (err) {
           return reject(err)
@@ -121,9 +121,9 @@ export function createLocation<Provider extends STORAGE_PROVIDERS>(
     })
   }
 
-  async function existsCachedArtifact(artifactId: string, teamId: string) {
+  async function existsCachedArtifact(artifactId: string, team: string) {
     return new Promise<void>((resolve, reject) => {
-      const artifactPath = join(teamId, artifactId)
+      const artifactPath = join(team, artifactId)
       location.exists(artifactPath, (err, exists) => {
         if (err) {
           return reject(err)
@@ -138,12 +138,12 @@ export function createLocation<Provider extends STORAGE_PROVIDERS>(
 
   async function createCachedArtifact(
     artifactId: string,
-    teamId: string,
+    team: string,
     artifact: Readable,
   ) {
     return pipeline(
       artifact,
-      location.createWriteStream(join(teamId, artifactId)),
+      location.createWriteStream(join(team, artifactId)),
     )
   }
 

--- a/test/azure-blob-storage.ts
+++ b/test/azure-blob-storage.ts
@@ -68,7 +68,7 @@ test('Azure Blob Storage', async (t) => {
    */
 
   const artifactId = crypto.randomBytes(20).toString('hex')
-  const teamId = 'superteam'
+  const team = 'superteam'
   const { createApp } = await import('../src/app.js')
   const app = createApp({ logger: false })
   await app.ready()
@@ -111,7 +111,7 @@ test('Azure Blob Storage', async (t) => {
   )
 
   await t.test(
-    'should return 400 when missing teamId query parameter',
+    'should return 400 when missing team query parameter',
     async () => {
       const response = await app.inject({
         method: 'GET',
@@ -123,7 +123,7 @@ test('Azure Blob Storage', async (t) => {
       assert.equal(response.statusCode, 400)
       assert.equal(
         response.json().message,
-        "querystring should have required property 'teamId'",
+        "querystring should have required property 'team'",
       )
     },
   )
@@ -136,7 +136,7 @@ test('Azure Blob Storage', async (t) => {
         authorization: 'Bearer changeme',
       },
       query: {
-        teamId: 'superteam',
+        team: 'superteam',
       },
     })
     assert.equal(response.statusCode, 404)
@@ -152,12 +152,12 @@ test('Azure Blob Storage', async (t) => {
         'content-type': 'application/octet-stream',
       },
       query: {
-        teamId,
+        team,
       },
       payload: Buffer.from('test cache data'),
     })
     assert.equal(response.statusCode, 200)
-    assert.deepEqual(response.json(), { urls: [`${teamId}/${artifactId}`] })
+    assert.deepEqual(response.json(), { urls: [`${team}/${artifactId}`] })
   })
 
   await t.test('should download an artifact', async () => {
@@ -168,7 +168,7 @@ test('Azure Blob Storage', async (t) => {
         authorization: 'Bearer changeme',
       },
       query: {
-        teamId,
+        team,
       },
     })
     assert.equal(response.statusCode, 200)
@@ -183,7 +183,7 @@ test('Azure Blob Storage', async (t) => {
         authorization: 'Bearer changeme',
       },
       query: {
-        teamId,
+        team,
       },
     })
     assert.equal(response.statusCode, 200)
@@ -198,7 +198,7 @@ test('Azure Blob Storage', async (t) => {
         authorization: 'Bearer changeme',
       },
       query: {
-        teamId,
+        team,
       },
     })
     assert.equal(response.statusCode, 404)
@@ -214,12 +214,12 @@ test('Azure Blob Storage', async (t) => {
         'content-type': 'application/octet-stream',
       },
       query: {
-        slug: teamId,
+        slug: team,
       },
       payload: Buffer.from('test cache data'),
     })
     assert.equal(response.statusCode, 200)
-    assert.deepEqual(response.json(), { urls: [`${teamId}/${artifactId}`] })
+    assert.deepEqual(response.json(), { urls: [`${team}/${artifactId}`] })
   })
 
   await t.test(

--- a/test/google-cloud-storage.ts
+++ b/test/google-cloud-storage.ts
@@ -67,7 +67,7 @@ test('Google Cloud Storage', async (t) => {
    */
 
   const artifactId = crypto.randomBytes(20).toString('hex')
-  const teamId = 'superteam'
+  const team = 'superteam'
 
   const { createApp } = await import('../src/app.js')
 
@@ -113,7 +113,7 @@ test('Google Cloud Storage', async (t) => {
     },
   )
   await t.test(
-    'should return 400 when missing teamId query parameter',
+    'should return 400 when missing team query parameter',
     async () => {
       const response = await app.inject({
         method: 'GET',
@@ -125,7 +125,7 @@ test('Google Cloud Storage', async (t) => {
       assert.equal(response.statusCode, 400)
       assert.equal(
         response.json().message,
-        "querystring should have required property 'teamId'",
+        "querystring should have required property 'team'",
       )
     },
   )
@@ -137,7 +137,7 @@ test('Google Cloud Storage', async (t) => {
         authorization: 'Bearer changeme',
       },
       query: {
-        teamId: 'superteam',
+        team: 'superteam',
       },
     })
     assert.equal(response.statusCode, 404)
@@ -152,12 +152,12 @@ test('Google Cloud Storage', async (t) => {
         'content-type': 'application/octet-stream',
       },
       query: {
-        teamId,
+        team,
       },
       payload: Buffer.from('test cache data'),
     })
     assert.equal(response.statusCode, 200)
-    assert.deepEqual(response.json(), { urls: [`${teamId}/${artifactId}`] })
+    assert.deepEqual(response.json(), { urls: [`${team}/${artifactId}`] })
   })
   await t.test('should download an artifact', async () => {
     const response = await app.inject({
@@ -167,7 +167,7 @@ test('Google Cloud Storage', async (t) => {
         authorization: 'Bearer changeme',
       },
       query: {
-        teamId,
+        team,
       },
     })
     assert.equal(response.statusCode, 200)
@@ -181,7 +181,7 @@ test('Google Cloud Storage', async (t) => {
         authorization: 'Bearer changeme',
       },
       query: {
-        teamId,
+        team,
       },
     })
     assert.equal(response.statusCode, 200)
@@ -195,7 +195,7 @@ test('Google Cloud Storage', async (t) => {
         authorization: 'Bearer changeme',
       },
       query: {
-        teamId,
+        team,
       },
     })
     assert.equal(response.statusCode, 404)
@@ -210,12 +210,12 @@ test('Google Cloud Storage', async (t) => {
         'content-type': 'application/octet-stream',
       },
       query: {
-        slug: teamId,
+        slug: team,
       },
       payload: Buffer.from('test cache data'),
     })
     assert.equal(response.statusCode, 200)
-    assert.deepEqual(response.json(), { urls: [`${teamId}/${artifactId}`] })
+    assert.deepEqual(response.json(), { urls: [`${team}/${artifactId}`] })
   })
   await t.test(
     'should return 200 when POST artifacts/events is called',
@@ -259,7 +259,7 @@ test('Google Cloud Storage ADC', async (t) => {
    */
 
   const artifactId = crypto.randomBytes(20).toString('hex')
-  const teamId = 'superteam2'
+  const team = 'superteam2'
 
   const { createApp } = await import('../src/app.js')
   const app = createApp({ logger: false })
@@ -286,11 +286,11 @@ test('Google Cloud Storage ADC', async (t) => {
         'content-type': 'application/octet-stream',
       },
       query: {
-        teamId,
+        team,
       },
       payload: Buffer.from('test cache data'),
     })
     assert.equal(response.statusCode, 200)
-    assert.deepEqual(response.json(), { urls: [`${teamId}/${artifactId}`] })
+    assert.deepEqual(response.json(), { urls: [`${team}/${artifactId}`] })
   })
 })

--- a/test/local.ts
+++ b/test/local.ts
@@ -29,7 +29,7 @@ test('local storage', async (t) => {
    */
   const { createApp } = await import('../src/app.js')
   const artifactId = crypto.randomBytes(20).toString('hex')
-  const teamId = 'superteam'
+  const team = 'superteam'
   const app = createApp({ logger: false })
   await app.ready()
 
@@ -67,7 +67,7 @@ test('local storage', async (t) => {
   )
 
   await t.test(
-    'should return 400 when missing teamId query parameter',
+    'should return 400 when missing team query parameter',
     async () => {
       const response = await app.inject({
         method: 'GET',
@@ -79,7 +79,7 @@ test('local storage', async (t) => {
       assert.equal(response.statusCode, 400)
       assert.equal(
         response.json().message,
-        "querystring should have required property 'teamId'",
+        "querystring should have required property 'team'",
       )
     },
   )
@@ -92,7 +92,7 @@ test('local storage', async (t) => {
         authorization: 'Bearer changeme',
       },
       query: {
-        teamId: 'superteam',
+        team: 'superteam',
       },
     })
     assert.equal(response.statusCode, 404)
@@ -108,12 +108,12 @@ test('local storage', async (t) => {
         'content-type': 'application/octet-stream',
       },
       query: {
-        teamId,
+        team,
       },
       payload: Buffer.from('test cache data'),
     })
     assert.equal(response.statusCode, 200)
-    assert.deepEqual(response.json(), { urls: [`${teamId}/${artifactId}`] })
+    assert.deepEqual(response.json(), { urls: [`${team}/${artifactId}`] })
   })
 
   await t.test('should download an artifact', async () => {
@@ -124,7 +124,7 @@ test('local storage', async (t) => {
         authorization: 'Bearer changeme',
       },
       query: {
-        teamId,
+        team,
       },
     })
     assert.equal(response.statusCode, 200)
@@ -139,7 +139,7 @@ test('local storage', async (t) => {
         authorization: 'Bearer changeme',
       },
       query: {
-        teamId,
+        team,
       },
     })
     assert.equal(response.statusCode, 200)
@@ -154,7 +154,7 @@ test('local storage', async (t) => {
         authorization: 'Bearer changeme',
       },
       query: {
-        teamId,
+        team,
       },
     })
     assert.equal(response.statusCode, 404)
@@ -170,12 +170,12 @@ test('local storage', async (t) => {
         'content-type': 'application/octet-stream',
       },
       query: {
-        slug: teamId,
+        slug: team,
       },
       payload: Buffer.from('test cache data'),
     })
     assert.equal(response.statusCode, 200)
-    assert.deepEqual(response.json(), { urls: [`${teamId}/${artifactId}`] })
+    assert.deepEqual(response.json(), { urls: [`${team}/${artifactId}`] })
   })
 
   await t.test(

--- a/test/minio.ts
+++ b/test/minio.ts
@@ -34,7 +34,7 @@ server.run((err) => {
   assert.equal(err, null)
   test('Minio', async (t) => {
     const artifactId = crypto.randomBytes(20).toString('hex')
-    const teamId = 'superteam'
+    const team = 'superteam'
 
     const { createApp } = await import('../src/app.js')
     const app = createApp({ logger: false })
@@ -81,7 +81,7 @@ server.run((err) => {
     )
 
     await t.test(
-      'should return 400 when missing teamId query parameter',
+      'should return 400 when missing team query parameter',
       async () => {
         const response = await app.inject({
           method: 'GET',
@@ -93,7 +93,7 @@ server.run((err) => {
         assert.equal(response.statusCode, 400)
         assert.equal(
           response.json().message,
-          "querystring should have required property 'teamId'",
+          "querystring should have required property 'team'",
         )
       },
     )
@@ -106,7 +106,7 @@ server.run((err) => {
           authorization: 'Bearer changeme',
         },
         query: {
-          teamId: 'superteam',
+          team: 'superteam',
         },
       })
       assert.equal(response.statusCode, 404)
@@ -122,12 +122,12 @@ server.run((err) => {
           'content-type': 'application/octet-stream',
         },
         query: {
-          teamId,
+          team,
         },
         payload: Buffer.from('test cache data'),
       })
       assert.equal(response.statusCode, 200)
-      assert.deepEqual(response.json(), { urls: [`${teamId}/${artifactId}`] })
+      assert.deepEqual(response.json(), { urls: [`${team}/${artifactId}`] })
     })
 
     await t.test('should download an artifact', async () => {
@@ -138,7 +138,7 @@ server.run((err) => {
           authorization: 'Bearer changeme',
         },
         query: {
-          teamId,
+          team,
         },
       })
       assert.equal(response.statusCode, 200)
@@ -153,7 +153,7 @@ server.run((err) => {
           authorization: 'Bearer changeme',
         },
         query: {
-          teamId,
+          team,
         },
       })
       assert.equal(response.statusCode, 200)
@@ -168,7 +168,7 @@ server.run((err) => {
           authorization: 'Bearer changeme',
         },
         query: {
-          teamId,
+          team,
         },
       })
       assert.equal(response.statusCode, 404)

--- a/test/s3.ts
+++ b/test/s3.ts
@@ -34,7 +34,7 @@ server.run((err) => {
   assert.equal(err, null)
   test('Amazon S3', async (t) => {
     const artifactId = crypto.randomBytes(20).toString('hex')
-    const teamId = 'superteam'
+    const team = 'superteam'
 
     const { createApp } = await import('../src/app.js')
     const app = createApp({ logger: false })
@@ -81,7 +81,7 @@ server.run((err) => {
     )
 
     await t.test(
-      'should return 400 when missing teamId query parameter',
+      'should return 400 when missing team query parameter',
       async () => {
         const response = await app.inject({
           method: 'GET',
@@ -93,7 +93,7 @@ server.run((err) => {
         assert.equal(response.statusCode, 400)
         assert.equal(
           response.json().message,
-          "querystring should have required property 'teamId'",
+          "querystring should have required property 'team'",
         )
       },
     )
@@ -106,7 +106,7 @@ server.run((err) => {
           authorization: 'Bearer changeme',
         },
         query: {
-          teamId: 'superteam',
+          team: 'superteam',
         },
       })
       assert.equal(response.statusCode, 404)
@@ -122,12 +122,12 @@ server.run((err) => {
           'content-type': 'application/octet-stream',
         },
         query: {
-          teamId,
+          team,
         },
         payload: Buffer.from('test cache data'),
       })
       assert.equal(response.statusCode, 200)
-      assert.deepEqual(response.json(), { urls: [`${teamId}/${artifactId}`] })
+      assert.deepEqual(response.json(), { urls: [`${team}/${artifactId}`] })
     })
 
     await t.test('should download an artifact', async () => {
@@ -138,7 +138,7 @@ server.run((err) => {
           authorization: 'Bearer changeme',
         },
         query: {
-          teamId,
+          team,
         },
       })
       assert.equal(response.statusCode, 200)
@@ -153,7 +153,7 @@ server.run((err) => {
           authorization: 'Bearer changeme',
         },
         query: {
-          teamId,
+          team,
         },
       })
       assert.equal(response.statusCode, 200)
@@ -168,7 +168,7 @@ server.run((err) => {
           authorization: 'Bearer changeme',
         },
         query: {
-          teamId,
+          team,
         },
       })
       assert.equal(response.statusCode, 404)


### PR DESCRIPTION
Use team over teamId

![Screenshot 2024-05-28 at 14 11 19](https://github.com/ducktors/turborepo-remote-cache/assets/11148959/1e2686d6-0365-47c3-93f7-c109ce90b55a)


Ref : https://github.com/vercel/turbo/issues/6765
