### PR TITLE
Raise the bodyLimit to 50MB from 1MB

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ const app = createApp({
   // https://fastify.dev/docs/latest/Reference/Server/#bodylimit
   // Here, we raise it to 50 MB (50 * 1024 * 1024).
   // number is measured in Bytes
-  bodyLimit: 52428800
+  bodyLimit: 52428800,
 })
 
 closeWithGrace(

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,11 @@ import { env } from './env.js'
 
 const app = createApp({
   trustProxy: true,
+  // Default is 1MB
+  // https://fastify.dev/docs/latest/Reference/Server/#bodylimit
+  // Here, we raise it to 50 MB (50 * 1024 * 1024).
+  // number is measured in Bytes
+  bodyLimit: 52428800
 })
 
 closeWithGrace(


### PR DESCRIPTION
## In this PR:

- Bug fix (non-breaking change which fixes an issue)

## Issues reference:

Related: #366 

I have a library that is 3.3MB right now, and I kinda "arbitrarily" chose 50MB, but I figure if some build assets could include images, it may be good to bump further.

Any larger than that though, and... folks should probably statically host those images somewhere.


-------------


Alternatively, I see (in #366) there is a `BODY_LIMIT` environment variable -- must be a fastify thing 😅 

I was not able to find that in fastify's docs though?

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ducktors/turborepo-remote-cache/pulls) for the same update/change?
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
* [x] Have you lint your code with `pnpm lint` locally prior to submission?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran build with `pnpm build` of your changes locally?
* [x] Have you successfully ran tests with `pnpm test` of your changes locally?
  * [ ] aside from the minio test -- address already in use error
* [x] Have you commit using [Conventional Commits](https://github.com/ducktors/turborepo-remote-cache#how-to-commit)?
