### PR TITLE
fix: Use BODY_LIMIT when creating app

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,7 @@ const app = createApp({
   trustProxy: true,
   // Default is 1MB
   // https://fastify.dev/docs/latest/Reference/Server/#bodylimit
-  // Here, we raise it to 50 MB (50 * 1024 * 1024).
-  // number is measured in Bytes
-  bodyLimit: 52428800,
+  bodyLimit: env.get().BODY_LIMIT,
 })
 
 closeWithGrace(


### PR DESCRIPTION
## In this PR:

- Bug fix (non-breaking change which fixes an issue)

The BODY_LIMIT env variable was being used in the content type parser, but not when creating the fastify app. This meant the practical body limit could not be raised past 50MB.

This PR uses the BODY_LIMIT var for both values.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ducktors/turborepo-remote-cache/pulls) for the same update/change?
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
* [x] Have you lint your code with `pnpm lint` locally prior to submission?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran build with `pnpm build` of your changes locally?
* [x] Have you successfully ran tests with `pnpm test` of your changes locally?
* [x] Have you commit using [Conventional Commits](https://github.com/ducktors/turborepo-remote-cache#how-to-commit)?
