### PR TITLE
fix: import package.json to work with bundlers

### DIFF
--- a/src/plugins/remote-cache/routes/get-status.ts
+++ b/src/plugins/remote-cache/routes/get-status.ts
@@ -1,21 +1,12 @@
-import { readFileSync } from 'fs'
 import type { Server } from 'http'
-import { dirname, join } from 'path'
-import { fileURLToPath } from 'url'
 import type {
   RawReplyDefaultExpression,
   RawRequestDefaultExpression,
   RouteOptions,
 } from 'fastify'
+import packageJson from '../../../../package.json'
 import { type Params, type Querystring } from './schema.js'
 import { statusRouteSchema } from './status-schema.js'
-
-// Get package.json version
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const packageJson = JSON.parse(
-  readFileSync(join(__dirname, '../../../../package.json'), 'utf8'),
-)
 
 export const getStatus: RouteOptions<
   Server,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "outDir": "dist",
     "inlineSourceMap": true,
     "declaration": false,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "resolveJsonModule": true
   },
   "include": [
     "./src/**/*.ts"


### PR DESCRIPTION
## In this PR:

- Bug fix (non-breaking change which fixes an issue)
Imports package.json in the get-status handler so that the package can be bundled (as with deployment to AWS Lambda).

## Issues reference:
 - https://github.com/ducktors/turborepo-remote-cache/issues/501

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ducktors/turborepo-remote-cache/pulls) for the same update/change?
* [x] Have you lint your code with `pnpm lint` locally prior to submission?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran build with `pnpm build` of your changes locally?
* [x] Have you successfully ran tests with `pnpm test` of your changes locally?
* [x] Have you commit using [Conventional Commits](https://github.com/ducktors/turborepo-remote-cache#how-to-commit)?
