### PR TITLE
docs: adding bun install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ It supports several storage providers and deploys environments. Moreover, the pr
 
 3. Install dependencies
 
-   `pnpm install`
+   `pnpm install or bun install`
 
 4. Copy example variables
 


### PR DESCRIPTION
Updated the  file to include bun install v1.2.5-canary.47 (078318f3)

Checked 981 installs across 1027 packages (no changes) [170.00ms] as an installation option.