### PR TITLE
fix: S3 - store upload promise early in order to complete createWriteStream

### DIFF
--- a/src/plugins/remote-cache/storage/s3.ts
+++ b/src/plugins/remote-cache/storage/s3.ts
@@ -72,21 +72,21 @@ export function createS3({
     },
     createWriteStream: (key: string) => {
       const passThrough = new PassThrough()
+      const upload = new Upload({
+        client,
+        params: { Bucket: bucket, Key: key, Body: passThrough },
+      })
+
+      const uploadPromise = upload.done()
+
       const writeStream = new Writable({
         write(chunk, encoding, callback) {
           passThrough.write(chunk, encoding, callback)
         },
         final(callback) {
           passThrough.end()
-          upload
-            .done()
-            .then(() => callback())
-            .catch(callback)
+          uploadPromise.then(() => callback()).catch(callback)
         },
-      })
-      const upload = new Upload({
-        client,
-        params: { Bucket: bucket, Key: key, Body: passThrough },
       })
 
       return writeStream


### PR DESCRIPTION
## In this PR:

- Fixes issue on S3 `createWriteStream` where the process never actually reaches final to write the cache on the S3 storage; this causes turbobuild to throw timeout error when trying to write cache.

## Issues reference:
- The issue comes from latest change [to update aws-sdk to v3](https://github.com/ducktors/turborepo-remote-cache/pull/534) as part of issue https://github.com/ducktors/turborepo-remote-cache/issues/323

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ducktors/turborepo-remote-cache/pulls) for the same update/change?
* [x] Have you linted your code locally with `pnpm lint` before submission?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully built locally with `pnpm build`?
* [x] Have you successfully tested locally with `pnpm test`?
* [x] Have you committed using [Conventional Commits](https://github.com/ducktors/turborepo-remote-cache#how-to-commit)?
