### PR TITLE
fix: resolve BODY_LIMIT defensively and surface it at startup (#758)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ build
 **/certs
 .omc
 docs/superpowers
+.pnpm-store

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ build
 # Certs, if placed locally for testing
 **/certs
 .omc
+docs/superpowers

--- a/src/app.ts
+++ b/src/app.ts
@@ -78,6 +78,9 @@ export function createApp(
             ? { message: err.message, ...err.data }
             : { message: err.output.payload.message },
         )
+    } else if (err.statusCode != null && err.statusCode < 500) {
+      reply.log.warn(err)
+      reply.code(err.statusCode).send({ message: err.message })
     } else {
       request.log.error(err)
       reply.code(500).send({ message: err.message })

--- a/src/env.ts
+++ b/src/env.ts
@@ -20,6 +20,10 @@ export const STORAGE_PROVIDERS = {
 export type STORAGE_PROVIDERS =
   typeof STORAGE_PROVIDERS[keyof typeof STORAGE_PROVIDERS]
 
+// Schema default for BODY_LIMIT (100 MB). Exported so the runtime fallback uses
+// the same value as the schema's `default`.
+export const BODY_LIMIT_DEFAULT = 104857600
+
 const schema = Type.Object(
   {
     NODE_ENV: Type.Optional(
@@ -43,7 +47,7 @@ const schema = Type.Object(
     STORAGE_PROVIDER: Type.Optional(
       Type.Enum(STORAGE_PROVIDERS, { default: STORAGE_PROVIDERS.LOCAL }),
     ),
-    BODY_LIMIT: Type.Optional(Type.Number({ default: 104857600 })),
+    BODY_LIMIT: Type.Optional(Type.Number({ default: BODY_LIMIT_DEFAULT })),
     STORAGE_PATH: Type.Optional(Type.String()),
     STORAGE_PATH_USE_TMP_FOLDER: Type.Optional(Type.Boolean({ default: true })),
     HTTP2: Type.Optional(Type.Boolean({ default: false })),
@@ -102,4 +106,25 @@ export const env = {
   get() {
     return _env
   },
+}
+
+/**
+ * Resolves a candidate BODY_LIMIT value to one that is safe to hand to
+ * fastify. If the input is not a finite positive integer (e.g. NaN, 0,
+ * negative, non-numeric) we fall back to the schema default and return a
+ * warning string so the caller can surface it through its logger.
+ */
+export function resolveBodyLimit(input: unknown): {
+  value: number
+  warning?: string
+} {
+  if (typeof input === 'number' && Number.isFinite(input) && input > 0) {
+    return { value: Math.floor(input) }
+  }
+  return {
+    value: BODY_LIMIT_DEFAULT,
+    warning: `BODY_LIMIT value ${String(
+      input,
+    )} is not a positive finite number; falling back to default ${BODY_LIMIT_DEFAULT}`,
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,23 @@
 import closeWithGrace from 'close-with-grace'
 
 import { createApp } from './app.js'
-import { env } from './env.js'
+import { env, resolveBodyLimit } from './env.js'
+
+const { value: bodyLimit, warning: bodyLimitWarning } = resolveBodyLimit(
+  env.get().BODY_LIMIT,
+)
 
 const app = createApp({
   trustProxy: true,
   // Default is 1MB
   // https://fastify.dev/docs/latest/Reference/Server/#bodylimit
-  bodyLimit: env.get().BODY_LIMIT,
+  bodyLimit,
 })
+
+if (bodyLimitWarning) {
+  app.log.warn(bodyLimitWarning)
+}
+app.log.info({ bodyLimit }, 'Server bodyLimit configured')
 
 closeWithGrace(
   { delay: 10000 },

--- a/src/plugins/remote-cache/index.ts
+++ b/src/plugins/remote-cache/index.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from 'fastify'
-import { STORAGE_PROVIDERS } from '../../env.js'
+import { STORAGE_PROVIDERS, resolveBodyLimit } from '../../env.js'
 import auth from './auth/index.js'
 import {
   artifactsEvents,
@@ -18,7 +18,12 @@ async function turboRemoteCache(
     provider?: STORAGE_PROVIDERS
   },
 ) {
-  const bodyLimit = <number>instance.config.BODY_LIMIT
+  const { value: bodyLimit, warning: bodyLimitWarning } = resolveBodyLimit(
+    instance.config.BODY_LIMIT,
+  )
+  if (bodyLimitWarning) {
+    instance.log.warn(bodyLimitWarning)
+  }
   const { apiVersion = 'v8', provider = STORAGE_PROVIDERS.LOCAL } = options
 
   instance.addContentTypeParser<Buffer>(

--- a/test/body-limit.ts
+++ b/test/body-limit.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+
+const TEN_MB = 10 * 1024 * 1024
+
+const baseTestEnv = {
+  NODE_ENV: 'test',
+  PORT: 3000,
+  LOG_LEVEL: 'info',
+  LOG_MODE: 'stdout',
+  LOG_FILE: 'server.log',
+  AUTH_MODE: 'none',
+  STORAGE_PROVIDER: 'local',
+  STORAGE_PATH: join(tmpdir(), 'turborepo-remote-cache-test-body-limit'),
+}
+
+test('BODY_LIMIT wiring', async (t) => {
+  await t.test(
+    'accepts payload below configured BODY_LIMIT',
+    async (subTest) => {
+      const testEnv = { ...baseTestEnv, BODY_LIMIT: TEN_MB }
+      Object.assign(process.env, testEnv)
+      const { env } = await import('../src/env.js')
+      subTest.mock.method(env, 'get', () => testEnv)
+
+      const { createApp } = await import('../src/app.js')
+      const app = createApp({ logger: false, bodyLimit: TEN_MB })
+      await app.ready()
+
+      const artifactId = crypto.randomBytes(20).toString('hex')
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/v8/artifacts/${artifactId}`,
+        headers: { 'content-type': 'application/octet-stream' },
+        query: { team: 'superteam' },
+        // 5 MB — well below the 10 MB limit
+        payload: Buffer.alloc(5 * 1024 * 1024, 1),
+      })
+
+      assert.equal(response.statusCode, 200)
+      assert.deepEqual(response.json(), {
+        urls: [`superteam/${artifactId}`],
+      })
+
+      await app.close()
+    },
+  )
+
+  await t.test(
+    'rejects payload above configured BODY_LIMIT with 413',
+    async (subTest) => {
+      const testEnv = { ...baseTestEnv, BODY_LIMIT: TEN_MB }
+      Object.assign(process.env, testEnv)
+      const { env } = await import('../src/env.js')
+      subTest.mock.method(env, 'get', () => testEnv)
+
+      const { createApp } = await import('../src/app.js')
+      const app = createApp({ logger: false, bodyLimit: TEN_MB })
+      await app.ready()
+
+      const artifactId = crypto.randomBytes(20).toString('hex')
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/v8/artifacts/${artifactId}`,
+        headers: { 'content-type': 'application/octet-stream' },
+        query: { team: 'superteam' },
+        // 15 MB — exceeds the 10 MB limit
+        payload: Buffer.alloc(15 * 1024 * 1024, 1),
+      })
+
+      assert.equal(response.statusCode, 413)
+
+      await app.close()
+    },
+  )
+
+  await t.test(
+    'resolveBodyLimit falls back to default on invalid input',
+    async () => {
+      const { resolveBodyLimit, BODY_LIMIT_DEFAULT } = await import(
+        '../src/env.js'
+      )
+
+      // Each of these should fall back to BODY_LIMIT_DEFAULT.
+      const invalidInputs: unknown[] = [
+        Number.NaN,
+        0,
+        -1,
+        Number.POSITIVE_INFINITY,
+        'not-a-number',
+        undefined,
+        null,
+      ]
+      for (const input of invalidInputs) {
+        const { value, warning } = resolveBodyLimit(input)
+        assert.equal(
+          value,
+          BODY_LIMIT_DEFAULT,
+          `expected fallback for input ${String(input)}`,
+        )
+        assert.ok(warning, `expected warning for input ${String(input)}`)
+      }
+
+      // Valid input passes through.
+      const valid = resolveBodyLimit(TEN_MB)
+      assert.equal(valid.value, TEN_MB)
+      assert.equal(valid.warning, undefined)
+    },
+  )
+})

--- a/test/body-limit.ts
+++ b/test/body-limit.ts
@@ -6,7 +6,7 @@ import { test } from 'node:test'
 
 const TEN_MB = 10 * 1024 * 1024
 
-const baseTestEnv = {
+const testEnv = {
   NODE_ENV: 'test',
   PORT: 3000,
   LOG_LEVEL: 'info',
@@ -15,65 +15,58 @@ const baseTestEnv = {
   AUTH_MODE: 'none',
   STORAGE_PROVIDER: 'local',
   STORAGE_PATH: join(tmpdir(), 'turborepo-remote-cache-test-body-limit'),
+  BODY_LIMIT: TEN_MB,
 }
 
 test('BODY_LIMIT wiring', async (t) => {
-  await t.test(
-    'accepts payload below configured BODY_LIMIT',
-    async (subTest) => {
-      const testEnv = { ...baseTestEnv, BODY_LIMIT: TEN_MB }
-      Object.assign(process.env, testEnv)
-      const { env } = await import('../src/env.js')
-      subTest.mock.method(env, 'get', () => testEnv)
+  /**
+   * MOCKS
+   */
+  Object.assign(process.env, testEnv)
+  const { env } = await import('../src/env.js')
+  t.mock.method(env, 'get', () => {
+    return testEnv
+  })
+  /**
+   * END MOCKS
+   */
+  const { createApp } = await import('../src/app.js')
+  const app = createApp({ logger: false, bodyLimit: TEN_MB })
+  await app.ready()
 
-      const { createApp } = await import('../src/app.js')
-      const app = createApp({ logger: false, bodyLimit: TEN_MB })
-      await app.ready()
+  await t.test('accepts payload below configured BODY_LIMIT', async () => {
+    const artifactId = crypto.randomBytes(20).toString('hex')
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/v8/artifacts/${artifactId}`,
+      headers: { 'content-type': 'application/octet-stream' },
+      query: { team: 'superteam' },
+      payload: Buffer.alloc(5 * 1024 * 1024, 1),
+    })
 
-      const artifactId = crypto.randomBytes(20).toString('hex')
-      const response = await app.inject({
-        method: 'PUT',
-        url: `/v8/artifacts/${artifactId}`,
-        headers: { 'content-type': 'application/octet-stream' },
-        query: { team: 'superteam' },
-        // 5 MB — well below the 10 MB limit
-        payload: Buffer.alloc(5 * 1024 * 1024, 1),
-      })
-
-      assert.equal(response.statusCode, 200)
-      assert.deepEqual(response.json(), {
-        urls: [`superteam/${artifactId}`],
-      })
-
-      await app.close()
-    },
-  )
+    assert.equal(response.statusCode, 200)
+    assert.deepEqual(response.json(), {
+      urls: [`superteam/${artifactId}`],
+    })
+  })
 
   await t.test(
     'rejects payload above configured BODY_LIMIT with 413',
-    async (subTest) => {
-      const testEnv = { ...baseTestEnv, BODY_LIMIT: TEN_MB }
-      Object.assign(process.env, testEnv)
-      const { env } = await import('../src/env.js')
-      subTest.mock.method(env, 'get', () => testEnv)
-
-      const { createApp } = await import('../src/app.js')
-      const app = createApp({ logger: false, bodyLimit: TEN_MB })
-      await app.ready()
-
+    async () => {
       const artifactId = crypto.randomBytes(20).toString('hex')
       const response = await app.inject({
         method: 'PUT',
         url: `/v8/artifacts/${artifactId}`,
         headers: { 'content-type': 'application/octet-stream' },
         query: { team: 'superteam' },
-        // 15 MB — exceeds the 10 MB limit
         payload: Buffer.alloc(15 * 1024 * 1024, 1),
       })
 
       assert.equal(response.statusCode, 413)
-
-      await app.close()
+      // The app's error handler now forwards err.statusCode for client errors,
+      // so the underlying fastify message reaches the client instead of being
+      // masked as a generic 500.
+      assert.match(response.json().message, /too large/i)
     },
   )
 
@@ -84,7 +77,6 @@ test('BODY_LIMIT wiring', async (t) => {
         '../src/env.js'
       )
 
-      // Each of these should fall back to BODY_LIMIT_DEFAULT.
       const invalidInputs: unknown[] = [
         Number.NaN,
         0,
@@ -104,10 +96,11 @@ test('BODY_LIMIT wiring', async (t) => {
         assert.ok(warning, `expected warning for input ${String(input)}`)
       }
 
-      // Valid input passes through.
       const valid = resolveBodyLimit(TEN_MB)
       assert.equal(valid.value, TEN_MB)
       assert.equal(valid.warning, undefined)
     },
   )
+
+  await app.close()
 })


### PR DESCRIPTION
## Summary

Fixes #758. Users reported `BODY_LIMIT` being silently ignored — env reaches the process correctly, yet fastify still rejects PUTs above 1 MB (fastify 5's default). This PR closes two related gaps:

- **Defensive resolution.** New `resolveBodyLimit()` helper in `src/env.ts` falls back to the schema default (100 MB) with a logged warning when the configured value is `NaN`, zero, negative, or non-numeric — instead of silently degrading to fastify's 1 MB.
- **Observability.** Server now logs `Server bodyLimit configured` with the resolved value at startup, so operators can confirm exactly what fastify received instead of inferring from request failures.
- **Two wiring paths covered.** Both `src/index.ts` (server-level `Fastify({ bodyLimit })`) and `src/plugins/remote-cache/index.ts` (the `application/octet-stream` content-type parser) use the helper. The plugin's previous `<number>instance.config.BODY_LIMIT` type-only cast did nothing at runtime; it's now a real check.
- **Adjacent defect fix.** While writing the regression test, the existing `setErrorHandler` in `src/app.ts` was discovered to forward all non-Boom non-validation errors as 500 — masking `FST_ERR_CTP_BODY_TOO_LARGE` (413) and matching the reporter's "413/500" observation. Handler now forwards `err.statusCode` for client errors (< 500) while preserving the 500 behavior for server-side faults.

## Test plan

- [x] `pnpm test` — 111/111 pass (3 new subtests under "BODY_LIMIT wiring")
- [x] `pnpm lint` clean
- [x] `pnpm check:types` clean
- [x] `pnpm build` clean
- [ ] Smoke-test against a built image with `BODY_LIMIT=524288000` and a 43 MB PUT (reproduces the reporter's scenario)
- [ ] Confirm the new `Server bodyLimit configured` log line lands in container stdout

## Notes

- No env schema change. No new env vars. Backwards-compatible.
- #757 (JWT error reporting) is a separate defect with the JWT plugin's own error handler — not addressed here.