### PR TITLE
fix(auth/jwt): surface upstream JWT errors and log every auth failure (#757)

### DIFF
--- a/src/plugins/remote-cache/auth/jwt.ts
+++ b/src/plugins/remote-cache/auth/jwt.ts
@@ -56,13 +56,15 @@ export default fp(async (fastify) => {
     async (error: Error & { code?: string; statusCode?: number }, req, res) => {
       if (isBoom(error)) {
         throw error
-      } else if (error.code?.startsWith('FST_JWT_')) {
-        throw new Boom(error.message, {
-          statusCode: error.statusCode || 500,
-        })
-      } else {
-        throw unauthorized()
       }
+      req.log.warn(
+        { err: error, code: error.code },
+        'JWT authentication failed',
+      )
+      if (typeof error.statusCode === 'number' && error.statusCode < 500) {
+        throw new Boom(error.message, { statusCode: error.statusCode })
+      }
+      throw unauthorized()
     },
   )
 })

--- a/src/plugins/remote-cache/auth/jwt.ts
+++ b/src/plugins/remote-cache/auth/jwt.ts
@@ -57,13 +57,17 @@ export default fp(async (fastify) => {
       if (isBoom(error)) {
         throw error
       }
-      req.log.warn(
-        { err: error, code: error.code },
-        'JWT authentication failed',
-      )
       if (typeof error.statusCode === 'number' && error.statusCode < 500) {
+        req.log.warn(
+          { err: error, code: error.code },
+          'JWT authentication failed',
+        )
         throw new Boom(error.message, { statusCode: error.statusCode })
       }
+      req.log.error(
+        { err: error, code: error.code },
+        'Unexpected error in JWT handler',
+      )
       throw unauthorized()
     },
   )

--- a/test/jwt-auth.ts
+++ b/test/jwt-auth.ts
@@ -51,6 +51,14 @@ describe('JWT auth', async () => {
         },
       })
       assert.equal(resp.statusCode, 401)
+      // Should not be the default generic Boom "Unauthorized" — must carry
+      // a useful reason from fastify-jwt-jwks (e.g. "Invalid token.").
+      const message = resp.json().message
+      assert.notEqual(message, 'Unauthorized')
+      assert.ok(
+        typeof message === 'string' && message.length > 0,
+        `expected non-empty message, got: ${JSON.stringify(message)}`,
+      )
     })
     await t.test('Fails for invalid token', async () => {
       const token = invalidJwksMock.token()
@@ -65,6 +73,31 @@ describe('JWT auth', async () => {
         },
       })
       assert.equal(resp.statusCode, 401)
+      const message = resp.json().message
+      assert.notEqual(message, 'Unauthorized')
+      assert.ok(
+        typeof message === 'string' && message.length > 0,
+        `expected non-empty message, got: ${JSON.stringify(message)}`,
+      )
+    })
+    await t.test('Fails for expired token', async () => {
+      // exp = 1 → unix-epoch + 1 second, very firmly in the past.
+      const expiredToken = jwksMock.token({ exp: 1 })
+      const resp = await app.inject({
+        method: 'GET',
+        url: '/v8/artifacts/123',
+        headers: {
+          authorization: `Bearer ${expiredToken}`,
+        },
+        query: {
+          team: 'asd',
+        },
+      })
+      assert.equal(resp.statusCode, 401)
+      // fastify-jwt-jwks maps the underlying "token expired" jsonwebtoken
+      // error to the message "Expired token." — assert case-insensitively
+      // to stay resilient to upstream wording tweaks.
+      assert.match(resp.json().message, /expired/i)
     })
     await t.test('Valid token', async (t1) => {
       const artifactId = randomUUID()


### PR DESCRIPTION
## Summary

Fixes #757. Expired or invalid JWT tokens previously surfaced to clients as a context-free generic `401 {"message": "Unauthorized"}` with **nothing in server logs** indicating the cause. This PR makes JWT auth failures observable in two ways:

- **Server logs always show the underlying error.** Every non-Boom failure in the JWT plugin's `setErrorHandler` is now logged with the original error object: `warn` for client-side failures (4xx — expired/invalid/missing token), `error` for the rare 5xx fallback path (e.g. JWKS fetch failures).
- **Clients receive the underlying message.** The existing handler only forwarded messages for errors whose `code` started with `FST_JWT_*`. But `fastify-jwt-jwks` (which wraps `@fastify/jwt`) re-throws JWT verification failures as `http-errors` `Unauthorized` instances — those have `statusCode` and `message` but no `code`, so they fell into the silent `throw unauthorized()` branch. The structural `statusCode < 500` check now covers both error families uniformly.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Expired token | `401 {"message":"Unauthorized"}`, no logs | `401 {"message":"Expired token."}`, `warn` log |
| Invalid signature | `401 {"message":"Unauthorized"}`, no logs | `401 {"message":"Invalid token."}`, `warn` log |
| Missing header / `FST_JWT_*` errors | already forwarded ✓ | unchanged ✓ |
| Unknown error (5xx) | generic 401, no logs | generic 401, `error` log with original error |

## Test plan

- [x] `pnpm test` — 112/112 pass (1 new subtest: "Fails for expired token"; existing malformed/invalid subtests tightened with message assertions)
- [x] `pnpm lint` clean
- [x] `pnpm check:types` clean
- [x] `pnpm build` clean
- [ ] Smoke-check with an expired token against a deployed instance: confirm the 401 body now carries `Expired token.` and the server log contains a `warn` line with the original error

## Notes

- No public API change. No env var change. Backwards-compatible.
- The handler still returns a generic 401 for unknown server errors (5xx fallback) so we don't leak internals — but the original error is logged server-side.
- Verified against `fastify-jwt-jwks@3.0.0` (the version in `pnpm-lock.yaml`); the fix is robust to the v2.x error shape as well since both versions throw `http-errors` instances with `statusCode`.