### PR TITLE
fix(azure-blob-storage): await block blob upload so signed .tag writes persist

### DIFF
--- a/src/plugins/remote-cache/storage/azure-blob-storage.ts
+++ b/src/plugins/remote-cache/storage/azure-blob-storage.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'node:stream'
+import { PassThrough, Writable } from 'node:stream'
 import { BlobServiceClient } from '@azure/storage-blob'
 import { StorageProvider } from './index.js'
 
@@ -34,9 +34,17 @@ export function createAzureBlobStorage({
     },
     createWriteStream(artifactPath) {
       const blockBlobClient = containerClient.getBlockBlobClient(artifactPath)
-      const stream = new PassThrough()
-      blockBlobClient.uploadStream(stream)
-      return stream
+      const passThrough = new PassThrough()
+      const uploadPromise = blockBlobClient.uploadStream(passThrough)
+      return new Writable({
+        write(chunk, encoding, callback) {
+          passThrough.write(chunk, encoding, callback)
+        },
+        final(callback) {
+          passThrough.end()
+          uploadPromise.then(() => callback()).catch(callback)
+        },
+      })
     },
   }
 }

--- a/test/azure-blob-storage.ts
+++ b/test/azure-blob-storage.ts
@@ -1,7 +1,9 @@
 import assert from 'node:assert'
 import crypto from 'node:crypto'
-import { PassThrough, Readable } from 'node:stream'
+import { Readable } from 'node:stream'
 import { afterEach, mock, test } from 'node:test'
+import { BlobServiceClient } from '@azure/storage-blob'
+import { createAzureBlobStorage } from '../src/plugins/remote-cache/storage/azure-blob-storage.js'
 
 const testEnv = {
   NODE_ENV: 'test',
@@ -22,12 +24,11 @@ test('Azure Blob Storage', async (t) => {
    */
   const { BlobServiceClient } = await import('@azure/storage-blob')
 
-  const uploadStream = (stream) => {
-    const writable = new PassThrough()
-    return writable.pipe(stream)
-  }
-
-  const uploadStreamMock = mock.fn(uploadStream)
+  // Mirrors the real blockBlobClient.uploadStream, which returns
+  // Promise<BlobUploadCommonResponse>. The adapter now awaits this in `final`,
+  // so it must be a promise; the passed-in stream is still captured as
+  // arguments[0] for the "should upload an artifact" assertion below.
+  const uploadStreamMock = mock.fn((_stream) => Promise.resolve({}))
 
   mock.method(BlobServiceClient, 'fromConnectionString', () => ({
     getContainerClient: () => ({
@@ -239,5 +240,52 @@ test('Azure Blob Storage', async (t) => {
       assert.equal(response.statusCode, 200)
       assert.deepEqual(response.json(), {})
     },
+  )
+})
+
+test('createWriteStream completes only after Azure commits the upload', async () => {
+  // Isolated from the suite above: own mock so afterEach(mock.restoreAll) there
+  // cannot strip it, and a caller-controlled deferred upload promise so we can
+  // observe ordering deterministically (no Azurite, no timing race).
+  let resolveUpload!: (value: unknown) => void
+  const uploadPromise = new Promise((resolve) => {
+    resolveUpload = resolve
+  })
+
+  mock.method(BlobServiceClient, 'fromConnectionString', () => ({
+    getContainerClient: () => ({
+      getBlockBlobClient: () => ({
+        uploadStream: () => uploadPromise,
+      }),
+    }),
+  }))
+
+  const storage = createAzureBlobStorage({
+    containerName: 'turborepo-remote-cache-test',
+    connectionString: 'key1=value1;key2=value2',
+  })
+
+  const writeStream = storage.createWriteStream('superteam/hash.tag')
+  let finished = false
+  writeStream.on('finish', () => {
+    finished = true
+  })
+  writeStream.end('tag-payload')
+
+  // Flush microtasks/immediates: the payload has been fully written and ended.
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.equal(
+    finished,
+    false,
+    'write stream must not finish before the upload promise resolves',
+  )
+
+  resolveUpload({})
+  await uploadPromise
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.equal(
+    finished,
+    true,
+    'write stream must finish once the upload promise resolves',
   )
 })


### PR DESCRIPTION
## What

Fixes #831 — with `STORAGE_PROVIDER=azure-blob-storage` **and** `TURBO_REMOTE_CACHE_SIGNATURE_KEY` set, remote caching never hits: every `GET /v8/artifacts/:id` returns `404 {"message":"Artifact tag not found"}`.

## Root cause

`createWriteStream` in `src/plugins/remote-cache/storage/azure-blob-storage.ts` **fire-and-forgets** the upload:

```ts
createWriteStream(artifactPath) {
  const blockBlobClient = containerClient.getBlockBlobClient(artifactPath)
  const stream = new PassThrough()
  blockBlobClient.uploadStream(stream)   // promise never awaited
  return stream
}
```

`createCachedArtifactTag` (in `storage/index.ts`) writes the signature via `pipeline(Readable.from(tag), location.createWriteStream(...))`. `pipeline` resolves when the source finishes writing **into the `PassThrough`** — not when Azure has durably committed the block blob. For the tiny `<team>/<hash>.tag` payload the request returns `200` before `uploadStream` commits, so the tag blob is silently dropped. The `GET` path (with a signature key set) then `404`s on the missing tag → a permanently cold cache, with no error surfaced.

## Fix

Return a `Writable` that forwards chunks into an internal `PassThrough` and, in `final()`, ends it and **awaits** the `uploadStream` promise — so `pipeline()` resolves only after Azure durably commits, and upload errors propagate instead of vanishing. This is a verbatim port of the shape already used by the S3 adapter (`src/plugins/remote-cache/storage/s3.ts`), and the `StorageProvider.createWriteStream(): Writable` contract is unchanged (no consumer edits).

## Testing

`node:test` (via `tsx --test`) — no new deps.

- Updated the existing Azure test mock so `uploadStream` returns a `Promise` (the adapter now awaits it; the real SDK returns `Promise<BlobUploadCommonResponse>`).
- Added an isolated ordering test proving the write completes **only after** the upload promise resolves (a caller-controlled deferred promise; no Azurite / no timing race).

Verified locally: `pnpm check:types` ✅, `pnpm lint` (biome) ✅, full suite `pnpm test` **113/113** ✅. Guard proof: reverting only `createWriteStream` back to fire-and-forget makes the new test fail on *"write stream must not finish before the upload promise resolves"* while the rest stay green.

## Notes / out of scope

- `createReadStream` in the same adapter has a related smell (`blobClient.download().then(...)` unawaited, errors swallowed) — kept out of scope here; it belongs with #815 (surfacing backend failures, PR #816). Happy to follow up.
- Same fire-and-forget class as #791 / #656.
- Parity note: if the returned write stream is destroyed before `final()` runs, the upload promise's rejection has no `.catch` attached yet — this matches the existing `s3.ts` adapter exactly, and is strictly better than the prior fire-and-forget (which never handled upload errors at all).

Related: #791, #656, #815
