### PR TITLE
fix(env): use named Ajv export instead of default workaround

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -1,5 +1,5 @@
 import { Static, Type } from '@sinclair/typebox'
-import Ajv from 'ajv'
+import { Ajv } from 'ajv'
 import { envSchema } from 'env-schema'
 
 const NODE_ENVS = {
@@ -89,8 +89,7 @@ export type Config = Static<typeof schema>
 let _env: Config
 export function load(overrides?: Partial<Config>) {
   _env = envSchema<Static<typeof schema>>({
-    // we call the default method because Ajv provides wrong types. ref https://github.com/ajv-validator/ajv/issues/2132
-    ajv: new Ajv.default({
+    ajv: new Ajv({
       removeAdditional: true,
       useDefaults: true,
       coerceTypes: true,


### PR DESCRIPTION
## In this PR:

- Bug fix (non-breaking change which fixes an issue)

The Ajv package used to have a bug (that has been fixed since `v8.13`) which declared ESM exports incorrectly, so `import Ajv from 'ajv'` would produce the module wrapper instead of the constructor. The workaround that users had to implement was calling the `default` method to reach the actual class.

`turborepo-remote-cache` uses Ajv v8.18, so the workaround is no longer necessary. This PR simply imports Ajv via its named export so that we do not need to explicitly call the `default` method.

## Issues reference:
 - https://github.com/ajv-validator/ajv/issues/2132

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ducktors/turborepo-remote-cache/pulls) for the same update/change?
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
* [x] Have you linted your code locally with `pnpm lint` before submission?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] (Not applicable for this PR) Have you written new tests for your core changes, as applicable?
* [x] Have you successfully built locally with `pnpm build`?
* [x] Have you successfully tested locally with `pnpm test`?
* [x] Have you committed using [Conventional Commits](https://github.com/ducktors/turborepo-remote-cache#how-to-commit)?
